### PR TITLE
update .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-node_modules
 dist
 flow-typed


### PR DESCRIPTION
Каталог `node_modules` указывать не обязательно — линтер по умолчанию игнорирует эту директорию (https://eslint.org/docs/user-guide/configuring#eslintignore)