### PR TITLE
add: rule - imports should have an extension

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,5 +19,8 @@ parserOptions:
 
 rules:
   no-console: 0
-  import/extensions: 0 # FIXME: remove when rule will be adjusted for new nodejs version
+  import/extensions: # FIXME: remove when rule will be adjusted for new nodejs version
+    - error
+    - ignorePackages
+    - js: always
   no-underscore-dangle: [2, { "allow": ["__filename", "__dirname"] }]


### PR DESCRIPTION
If you fogot extension for internal import e.q. '.js' it couse an error - module not found