### PR TITLE
ci: upgrade codeclimate version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,7 +39,7 @@ jobs:
       # - name: Test & publish code coverage
       #   # Publish code coverage on Code Climate
       #   # https://github.com/paambaati/codeclimate-action
-      #   uses: paambaati/codeclimate-action@v4.0.0
+      #   uses: paambaati/codeclimate-action@v5.0.0
       #   # Add Code Climate secret key
       #   env:
       #     CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
It upgrades the [codeclimate action](https://github.com/paambaati/codeclimate-action) to the current version.
The v4.0.0 was giving errors on CI: `Error: File not found: '/home/runner/work/_actions/paambaati/codeclimate-action/v4.0.0/lib/main.js'`. Example of the run: [link](https://github.com/svidersky/frontend-project-46/actions/runs/7269613668/job/19807500200).