### PR TITLE
Disable SonarQube scan until SonarCloud is configured

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,11 @@ jobs:
       - run: make install
       - run: make lint
       - run: make test-coverage
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v7
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # NOTE: uncomment for use it
+      # Requires the hexlet-boilerplates_nodejs-package project in SonarCloud
+      # and a valid SONAR_TOKEN secret
+      # - name: SonarQube Scan
+        # uses: SonarSource/sonarqube-scan-action@v7
+        # env:
+          # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Why

Node CI has never been green in this repo — every run (including pushes to `main`) fails on the SonarQube Scan step with:

> Project not found. Please check the 'sonar.projectKey' and 'sonar.organization' properties, the 'SONAR_TOKEN' environment variable...

`make install`, `make lint` and `make test-coverage` all pass; only the scan is broken — the `hexlet-boilerplates_nodejs-package` project does not exist in SonarCloud (or the token has no access). This keeps every dependabot PR permanently red (#77, #78).

## What

Comment the scan step out the same way `php-package` does, with a note on what is required to re-enable it. `sonar-project.properties` is left in place — it is correct and will be used once the SonarCloud side exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)